### PR TITLE
Missing python module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-markdownextradata-plugin~=0.2.0
 mkdocs-exclude~=1.0.0
 jinja2~=3.0.3 # without specifying the version, the broken one will be installed https://github.com/mkdocs/mkdocs/issues/2799
 mkdocs-git-revision-date-localized-plugin~=1.1.0
+pygments~=2.12


### PR DESCRIPTION
Requirement not listed, mkdocs-material 6.2.8 has requirement Pygments>=2.4, but this version causes the build to fail with a message
```
ERROR   -  Error reading page 'Anjay_integrations/Implementing_LwM2M_objects_on_RaspberryPi.md': Pymdownx Highlight requires at least Pygments 2.12+ if enabling Pygments 
```