### PR TITLE
Enable redirects plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - run: gulp build 
       - run: pip install -Iv mkdocs-material==6.2.6
       - run: pip install mkdocs-git-revision-date-localized-plugin
+      - run: pip install mkdocs-redirects
 #      - run: docker run -v ${PWD}:/docs squidfunk/mkdocs-material:6.2.6 build 
       - run: pip install ghp-import
 #      - run: mkdocs --version

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,10 @@ markdown_extensions:
 plugins:
   - search
   - git-revision-date-localized
+  - redirects:
+        redirect_maps:
+            'IoT_quick_start/Device_onboarding.md': 'Coiote_IoT_DM/Quick_Start/Connect_device_quickstart.md'
+
 
 google_analytics:
   - UA-25246208-6

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mkdocs-exclude~=1.0.0
 jinja2~=3.0.0 # without specifying the version, the broken one will be installed https://github.com/mkdocs/mkdocs/issues/2799
 mkdocs-git-revision-date-localized-plugin~=1.1.0
 pygments~=2.12
+mkdocs-redirects~=1.2.0


### PR DESCRIPTION
Due to our latest DevZone restructuring, some links have been broken.

This redirects allows for easily redirects creation.

It directly solves one broken link:
- Broken link: https://iotdevzone.avsystem.com/docs/IoT_quick_start/Device_onboarding/
- Redirected link: https://iotdevzone.avsystem.com/docs/Coiote_IoT_DM/Quick_Start/Connect_device_quickstart/