### PR TITLE
remove outdated note from M5Stick integration

### DIFF
--- a/docs/LwM2M_Client/ESP32/M5Stick.md
+++ b/docs/LwM2M_Client/ESP32/M5Stick.md
@@ -17,10 +17,6 @@ Integrate your ESP32-based device to manage it via Coiote DM.
 
 0. Create a `nvs_config.csv` file and save it in your project directory. In the file, provide your credentials in [wifi_ssid], [wifi_password], [endpoint_name], [identity], [psk], [lwm2m_server_uri] (without the `[]` brackets). Use the following snippet as a template:
 
-    !!! important
-        The **Identity** parameter stands for both the device endpoint name and its PSK identity, therefore these two must be identical in Coiote DM.
-
-
     ```
     key,type,encoding,value
     config,namespace,,


### PR DESCRIPTION
This deleted note is outdated since the  `endpoint_name` parameter was added.